### PR TITLE
✨ Add refs forwarding to HOC

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import * as classNames from 'classnames'
-import { createElement } from 'react'
+import { createElement, forwardRef } from 'react'
 import { Classes, ClassesValueArray, processClasses } from './classNames'
 import { filterPropsToForward, tags } from './tags'
 import { CreateClassedComponent, Tag } from './types'
@@ -8,7 +8,7 @@ const tagDisplayName = (tag: Tag) => typeof tag === 'string' ? tag : tag.display
 
 const createClassed: any = (tag: Tag) => {
   return (classes: Classes<any>, ...placeholders: ClassesValueArray<any>) => {
-    const Hoc = (props: { className?: string }) => {
+    const Hoc = forwardRef((props: { className?: string }, ref) => {
 
       const className = classNames(
         processClasses(classes, props, placeholders),
@@ -17,8 +17,8 @@ const createClassed: any = (tag: Tag) => {
 
       const propsToForward = filterPropsToForward(tag, props)
 
-      return createElement(tag, { ...propsToForward, className })
-    }
+      return createElement(tag, { ...propsToForward, ref, className })
+    })
 
     Hoc.displayName = `Classed(${tagDisplayName(tag)})`
 

--- a/tests/classed.test.tsx
+++ b/tests/classed.test.tsx
@@ -36,6 +36,22 @@ describe('Basic tests', () => {
     )
   })
 
+  test('it forwards refs to the created elements', () => {
+    const ref = jest.fn()
+    const MenuLink = classed.a('')
+
+    create(
+      <MenuLink href="#" ref={ref}>foo</MenuLink>,
+        {
+        createNodeMock: (element) => {
+          return {type: element.type};
+        }
+      }
+    )
+
+    expect(ref.mock.calls[0]).toEqual([{ type: 'a' }])
+  })
+
   test('in fact it just fills the className props of the provided components', () => {
     const UnClassableLink = ({ className, ...props }: any) => <a {...props}>{className}</a>
 


### PR DESCRIPTION
Fixes #4 - this allows classed-components to forward refs using `forwardRef`. Super nifty for doing things like using `classed-components` with Next's `Link` component or any of the Radix components that rely heavily on refs.