### PR TITLE
Replaced classnames with clsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classed-components",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "CSS Classes for the component age. Apply your Css with the power of Javascript.",
   "keywords": [
     "classNames",
@@ -54,8 +54,8 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@emotion/is-prop-valid": "^1.1.0",
-    "classnames": "^2.3.1"
+    "@emotion/is-prop-valid": "^1.2.1",
+    "clsx": "^2.1.0"
   },
   "peerDependencies": {
     "react": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classed-components",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "description": "CSS Classes for the component age. Apply your Css with the power of Javascript.",
   "keywords": [
     "classNames",

--- a/src/classNames.ts
+++ b/src/classNames.ts
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 
 type BasicClassValue = string | { [id: string]: any } | undefined | boolean
 type ClassesValue<P> = BasicClassValue | ClassesValueArray<P> | ((props: P) => Classes<P>)
@@ -32,7 +32,7 @@ export const processClasses = <P>(
 }
 
 const preparePlaceholders = <P>(templateStringPlaceholders: ClassesValueArray<P>, props: P) => (
-  templateStringPlaceholders.map((placeholder) => classNames(processClasses(placeholder, props)))
+  templateStringPlaceholders.map((placeholder) => clsx(processClasses(placeholder, props)))
 )
 
 const compileClassnames = (placeholders: string[], classes: TemplateStringsArray) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import { clsx } from 'clsx'
 import { createElement, forwardRef } from 'react'
 import { Classes, ClassesValueArray, processClasses } from './classNames'
 import { filterPropsToForward, tags } from './tags'
@@ -8,7 +8,7 @@ const tagDisplayName = (tag: Tag) => (typeof tag === 'string' ? tag : tag.displa
 
 const createClassed: any = (tag: Tag) => (classes: Classes<any>, ...placeholders: ClassesValueArray<any>) => {
   const Hoc = forwardRef((props: { className?: string }, ref) => {
-    const className = classNames(
+    const className = clsx(
       processClasses(classes, props, placeholders),
       props.className,
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,17 +302,17 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@emotion/is-prop-valid@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz#29ef6be1e946fb4739f9707def860f316f668cde"
-  integrity sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==
+"@emotion/is-prop-valid@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz#23116cf1ed18bfeac910ec6436561ecb1a3885cc"
+  integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
   dependencies:
-    "@emotion/memoize" "^0.7.4"
+    "@emotion/memoize" "^0.8.1"
 
-"@emotion/memoize@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
-  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+"@emotion/memoize@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
+  integrity sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==
 
 "@eslint/eslintrc@^1.0.4":
   version "1.0.4"
@@ -1404,11 +1404,6 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
-  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
-
 cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
@@ -1461,6 +1456,11 @@ cliui@^7.0.2:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
+
+clsx@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
+  integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
 
 cmd-shim@^3.0.0, cmd-shim@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Hey Mathieu, 

first of all, I really appreciate your package, thanks for all the work you put into this!

In this PR I replaced the `classnames` package with the smaller and better performing [clsx](https://github.com/lukeed/clsx) library.

I also bumped `@emotion/is-prop-valid` to the latest version and upped the version to 2.1.0.


Kind Regards
Chris